### PR TITLE
fix(GitHub MCP Server): update header name

### DIFF
--- a/v0/servers/index.html
+++ b/v0/servers/index.html
@@ -19,7 +19,7 @@
              "url":"https://api.githubcopilot.com/mcp",
              "headers":[
                {
-                 "name":"Bearer",
+                 "name":"Authorization",
                  "description":"Token for authentication https://github.com/settings/personal-access-tokens/new",
                  "is_required":true,
                  "is_secret":true


### PR DESCRIPTION
## Description

We do not need to specify the `Bearer {token}` for GitHub, you can just have `Authorization` as header name and the token as value

Having the following hardcoded code (https://github.com/kortex-hub/kortex/blob/81bf042aa290b8c5390ac5c71c0288f6896d03b2/packages/main/src/plugin/mcp/mcp-registry.ts#L277-L286) is creating some issues while working on a more generic approach supporting local (npx, uvx)

cc @benoitf 
